### PR TITLE
Fixed typo

### DIFF
--- a/frontend/src/components/workflows/sweepPipeline/SubmissionFormCOR.tsx
+++ b/frontend/src/components/workflows/sweepPipeline/SubmissionFormCOR.tsx
@@ -296,7 +296,7 @@ const SubmissionFormCOR = (props: {
       <ParameterSweepForm values={sweepValues} onChange={setSweepValues} />
 
       <Typography variant="h6" sx={{ mt: 2 }}>
-        Workflow Parameterss
+        Workflow Parameters
       </Typography>
       <WorkflowParametersForm values={wfValues} onChange={setWfValues} />
 


### PR DESCRIPTION
Fixed typo in CoR finder form
("parameterss" changed to "parameters"")