### PR TITLE
Workkflow parameters form fix

### DIFF
--- a/frontend/src/components/workflows/WorkflowParametersForm.tsx
+++ b/frontend/src/components/workflows/WorkflowParametersForm.tsx
@@ -21,6 +21,13 @@ export default function WorkflowParametersForm({
   disabled?: boolean;
 }) {
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [memoryFieldError, setMemoryFieldError] = useState(false);
+  function onMemoryFieldChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) {
+    onChange({ ...values, memory: e.target.value });
+    setMemoryFieldError(!e.target.checkValidity());
+  }
 
   return (
     <Stack direction="column" spacing={2}>
@@ -80,9 +87,15 @@ export default function WorkflowParametersForm({
             size="small"
           />
           <TextField
+            error={memoryFieldError}
+            slotProps={{
+              htmlInput: {
+                pattern: "[0-9]+[GMK]i",
+              },
+            }}
             label="Memory"
             value={values.memory ?? ""}
-            onChange={(e) => onChange({ ...values, memory: e.target.value })}
+            onChange={(e) => onMemoryFieldChange(e)}
             disabled={disabled}
             fullWidth
             size="small"

--- a/frontend/src/components/workflows/WorkflowParametersForm.tsx
+++ b/frontend/src/components/workflows/WorkflowParametersForm.tsx
@@ -22,12 +22,6 @@ export default function WorkflowParametersForm({
 }) {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [memoryFieldError, setMemoryFieldError] = useState(false);
-  function onMemoryFieldChange(
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) {
-    onChange({ ...values, memory: e.target.value });
-    setMemoryFieldError(!e.target.checkValidity());
-  }
 
   return (
     <Stack direction="column" spacing={2}>
@@ -95,7 +89,10 @@ export default function WorkflowParametersForm({
             }}
             label="Memory"
             value={values.memory ?? ""}
-            onChange={(e) => onMemoryFieldChange(e)}
+            onChange={(e) => {
+              onChange({ ...values, memory: e.target.value });
+              setMemoryFieldError(!e.target.checkValidity());
+            }}
             disabled={disabled}
             fullWidth
             size="small"

--- a/frontend/src/components/workflows/WorkflowParametersForm.tsx
+++ b/frontend/src/components/workflows/WorkflowParametersForm.tsx
@@ -99,6 +99,11 @@ export default function WorkflowParametersForm({
             disabled={disabled}
             fullWidth
             size="small"
+            helperText={
+              memoryFieldError
+                ? "Must be a number followed by Ki, Mi or Gi"
+                : " "
+            }
           />
           <TextField
             label="Output Directory Name"


### PR DESCRIPTION
Added error checking to the Memory input TextField on the CentreFinder page that feeds back to the user when the value is incorrect