### PR TITLE
Restrict davidia selection functionality

### DIFF
--- a/frontend/src/components/crop/Plot.tsx
+++ b/frontend/src/components/crop/Plot.tsx
@@ -37,7 +37,6 @@ export default function ImagePlot({ image, max_pixel_value }: ImagePlotProps) {
                 // copy the value of currentSelection and set it to that again (dont change it)
                 // this stops regions being added if theyre not a rectangle
                 // however, the component still needs to refresh as the new selection region will be visible otherwise
-                // lmk if theres a better way to "force refresh" a component
                 setCurrentSelection([...currentSelection]);
               }
             }


### PR DESCRIPTION
Only allows 1 ROI at a time which must be rectangular