### PR TITLE
Refactor duplicate keycloak initialisation

### DIFF
--- a/frontend/src/RelayEnviornment.ts
+++ b/frontend/src/RelayEnviornment.ts
@@ -50,6 +50,7 @@ function ensureKeycloakInit(): Promise<boolean> {
     kcinitPromise = keycloak
       .init({
         onLoad: "login-required",
+        scope: import.meta.env.VITE_KEYCLOAK_SCOPE,
       })
       .catch((err: unknown) => {
         console.error("Keycloak init failed", err);
@@ -122,4 +123,10 @@ function createRelayEnvironment() {
   });
 }
 
-export const RelayEnvironment = createRelayEnvironment();
+export async function getRelayEnvironment(): Promise<Environment> {
+  await ensureKeycloakInit();
+  return new Environment({
+    network: Network.create(fetchFn, subscribe),
+    store: new Store(new RecordSource()),
+  });
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,28 +4,17 @@ import App from "./App";
 import { CssBaseline } from "@mui/material";
 import { ThemeProvider, DiamondTheme } from "@diamondlightsource/sci-react-ui";
 import { RelayEnvironmentProvider } from "react-relay";
-import { RelayEnvironment } from "./RelayEnviornment";
-import keycloak from "./keycloak";
+import { getRelayEnvironment } from "./RelayEnviornment";
 
-// Wait for Keycloak before rendering
-keycloak
-  .init({
-    onLoad: "login-required",
-    scope: import.meta.env.VITE_KEYCLOAK_SCOPE,
-  })
-  .then((authenticated) => {
-    if (authenticated) {
-      createRoot(document.getElementById("root")!).render(
-        <StrictMode>
-          <ThemeProvider theme={DiamondTheme} defaultMode="light">
-            <CssBaseline />
-            <RelayEnvironmentProvider environment={RelayEnvironment}>
-              <App />
-            </RelayEnvironmentProvider>
-          </ThemeProvider>
-        </StrictMode>
-      );
-    } else {
-      window.location.reload();
-    }
-  });
+getRelayEnvironment().then((environment) => {
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <ThemeProvider theme={DiamondTheme} defaultMode="light">
+        <CssBaseline />
+        <RelayEnvironmentProvider environment={environment}>
+          <App />
+        </RelayEnvironmentProvider>
+      </ThemeProvider>
+    </StrictMode>
+  );
+});


### PR DESCRIPTION
In particular, previously, the scope was only included in one of the two pieces of logic where keycloak was initialised. Now, the scope is in the single piece of logic where keycloak is initialised.