### PR TITLE
Remove normalisation functions from CoR pipeline

### DIFF
--- a/frontend/src/components/workflows/sweepPipeline/SubmissionFormCOR.tsx
+++ b/frontend/src/components/workflows/sweepPipeline/SubmissionFormCOR.tsx
@@ -161,16 +161,6 @@ const SubmissionFormCOR = (props: {
         parameters: updatedLoaderParams,
       },
       {
-        method: "normalize",
-        module_path: "tomopy.prep.normalize",
-        parameters: { cutoff: null, averaging: "mean" },
-      },
-      {
-        method: "minus_log",
-        module_path: "tomopy.prep.normalize",
-        parameters: {},
-      },
-      {
         method: "recon",
         module_path: "tomopy.recon.algorithm",
         parameters: {


### PR DESCRIPTION
In conjunction with the following change to the CoR sweep parameter schema used in the associated workflow template:
https://github.com/DiamondLightSource/imaging-workflows/pull/133.