### PR TITLE
Revert "Remove normalisation functions from CoR pipeline"

### DIFF
--- a/frontend/src/components/workflows/sweepPipeline/SubmissionFormCOR.tsx
+++ b/frontend/src/components/workflows/sweepPipeline/SubmissionFormCOR.tsx
@@ -161,6 +161,16 @@ const SubmissionFormCOR = (props: {
         parameters: updatedLoaderParams,
       },
       {
+        method: "normalize",
+        module_path: "tomopy.prep.normalize",
+        parameters: { cutoff: null, averaging: "mean" },
+      },
+      {
+        method: "minus_log",
+        module_path: "tomopy.prep.normalize",
+        parameters: {},
+      },
+      {
         method: "recon",
         module_path: "tomopy.recon.algorithm",
         parameters: {


### PR DESCRIPTION
Reverts DiamondLightSource/TomoHub#100

In tandem with the reversion done in the workflow template in https://github.com/DiamondLightSource/imaging-workflows/pull/144