### PR TITLE
Update backend's python base container image version

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
This is required due to httomo and associated libraries (including httomo-backends) moving to python 3.12+.