### PR TITLE
Serve multi-page tiffs as grayscale PNGs

### DIFF
--- a/backend/routers/proxy.py
+++ b/backend/routers/proxy.py
@@ -164,6 +164,18 @@ async def proxy_tiff_pages(
                                 / (array.max() - array.min())
                             )
                             img = Image.fromarray(normalized.astype(np.uint8))
+                        if img.mode == "F":
+                            array = np.array(img)
+                            # Shift all values so that smallest value is zero
+                            array -= array.min()
+                            # Distribute floating point values between min and max of `uint8`
+                            # (0 and 255), based on the range of the floating point values in
+                            # the array
+                            scale_factor = np.iinfo(np.uint8).max / (
+                                array.max() - array.min()
+                            )
+                            array *= scale_factor
+                            img = Image.fromarray(array)
                         img = img.convert("RGB")
 
                     # Save as PNG to BytesIO

--- a/backend/routers/proxy.py
+++ b/backend/routers/proxy.py
@@ -154,29 +154,28 @@ async def proxy_tiff_pages(
                         )
                     logger.info(f"Extracting page {page}, size: {img.size}")
 
-                    # Convert to RGB if necessary (TIFF might be in different modes)
-                    if img.mode not in ("RGB", "RGBA"):
-                        if img.mode == "I;16":
-                            array = np.array(img)
-                            normalized = (
-                                (array.astype(np.uint16) - array.min())
-                                * 255.0
-                                / (array.max() - array.min())
-                            )
-                            img = Image.fromarray(normalized.astype(np.uint8))
-                        if img.mode == "F":
-                            array = np.array(img)
-                            # Shift all values so that smallest value is zero
-                            array -= array.min()
-                            # Distribute floating point values between min and max of `uint8`
-                            # (0 and 255), based on the range of the floating point values in
-                            # the array
-                            scale_factor = np.iinfo(np.uint8).max / (
-                                array.max() - array.min()
-                            )
-                            array *= scale_factor
-                            img = Image.fromarray(array)
-                        img = img.convert("RGB")
+                    if img.mode == "I;16":
+                        array = np.array(img)
+                        normalized = (
+                            (array.astype(np.uint16) - array.min())
+                            * 255.0
+                            / (array.max() - array.min())
+                        )
+                        img = Image.fromarray(normalized.astype(np.uint8))
+                    if img.mode == "F":
+                        array = np.array(img)
+                        # Shift all values so that smallest value is zero
+                        array -= array.min()
+                        # Distribute floating point values between min and max of `uint8`
+                        # (0 and 255), based on the range of the floating point values in
+                        # the array
+                        scale_factor = np.iinfo(np.uint8).max / (
+                            array.max() - array.min()
+                        )
+                        array *= scale_factor
+                        img = Image.fromarray(array)
+
+                    img = img.convert("L")
 
                     # Save as PNG to BytesIO
                     png_buffer = BytesIO()


### PR DESCRIPTION
Fixes [IMGDA-785](https://jira.diamond.ac.uk/browse/IMGDA-785)
Fixes [IMGDA-637](https://jira.diamond.ac.uk/browse/IMGDA-637)

Note that there is no need to modify code in the frontend to deal with the change from RGBA to grayscale, namely, this code: https://github.com/DiamondLightSource/ImagingHub/blob/04bb321735ba552d698d6092019b327d70f7c41a/frontend/tomography/src/components/crop/SampleLoad.ts#L37-L40

The reason is that it appears that the grayscale PNG is somehow being converted to an RGBA PNG when the raw PNG data is decoded by the `image-pixels` package.

So, while there is still a conversion to RGBA, it's not being done by the backend anymore, and this somehow is still improving the performance, so this is what made the conversion-removal in the backend justifiable.