### PR TITLE
Adding workflows Resource component to the epsic part of imaginghub

### DIFF
--- a/frontend/ePSIC/src/App.tsx
+++ b/frontend/ePSIC/src/App.tsx
@@ -1,9 +1,11 @@
 import { WorkflowForm } from "./components/workflows/WorkflowForm";
+import { ResourceForm } from "./components/workflows/ResourceForm";
 
 export const App: React.FC = () => {
   return (
     <>
       <WorkflowForm />
+      <ResourceForm />
     </>
   );
 };

--- a/frontend/ePSIC/src/components/workflows/ResourceForm.tsx
+++ b/frontend/ePSIC/src/components/workflows/ResourceForm.tsx
@@ -1,0 +1,93 @@
+import React, { FC, ChangeEvent, useState } from "react";
+import {
+  Button,
+  MenuItem,
+  IconButton,
+  InputLabel,
+  Grid,
+  Select,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+  NumberField 
+} from "@mui/material";
+
+type FormRes = { cpus: string, gpus: string, nprocs: string; memory: string };
+
+const initialData: FormRes = {
+  cpus: "1",
+  gpus: "0",
+  nprocs: "8",
+  memory: "16Gi",
+};
+
+export const ResourceForm: FC = () => {
+  const [res, setRes] = useState<FormRes>(initialData);
+
+  return (
+    <Grid container justifyContent="center" spacing={1}>
+      <Grid size={3}>
+        <Stack direction="column" spacing={2}>
+          <InputLabel size="small" id="workflow-select-label">
+            Resources
+          </InputLabel>
+          <TextField
+            name="cpus"
+            label="cpus"
+            variant="outlined"
+            size="small"
+            placeholder="8"
+            type="text"
+            value={res.cpus}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const value = e.target.value;
+              setRes((prev) => ({ ...prev, cpus: value}));
+            }}
+          />
+          <TextField
+            name="gpus"
+            label="gpus"
+            variant="outlined"
+            size="small"
+            placeholder="1"
+            type="text"
+            value={res.gpus}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const value = e.target.value;
+              setRes((prev) => ({ ...prev, gpus: value}));
+            }}
+          />
+          <TextField
+            name="nprocs"
+            label="nprocs"
+            variant="outlined"
+            size="small"
+            placeholder="8"
+            type="text"
+            value={res.nprocs}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const value = e.target.value;
+              setRes((prev) => ({ ...prev, nprocs: value}));
+            }}
+          />
+          <TextField
+            name="memory"
+            label="memory"
+            variant="outlined"
+            size="small"
+            placeholder="16Gi"
+            type="text"
+            value={res.memory}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              const value = e.target.value;
+              setRes((prev) => ({ ...prev, memory: value}));
+            }}
+          />
+        </Stack>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default ResourceForm;

--- a/frontend/ePSIC/src/components/workflows/ResourceForm.tsx
+++ b/frontend/ePSIC/src/components/workflows/ResourceForm.tsx
@@ -10,10 +10,10 @@ import {
   TextField,
   Tooltip,
   Typography,
-  NumberField 
+  NumberField,
 } from "@mui/material";
 
-type FormRes = { cpus: string, gpus: string, nprocs: string; memory: string };
+type FormRes = { cpus: string; gpus: string; nprocs: string; memory: string };
 
 const initialData: FormRes = {
   cpus: "1",
@@ -42,7 +42,7 @@ export const ResourceForm: FC = () => {
             value={res.cpus}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const value = e.target.value;
-              setRes((prev) => ({ ...prev, cpus: value}));
+              setRes((prev) => ({ ...prev, cpus: value }));
             }}
           />
           <TextField
@@ -55,7 +55,7 @@ export const ResourceForm: FC = () => {
             value={res.gpus}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const value = e.target.value;
-              setRes((prev) => ({ ...prev, gpus: value}));
+              setRes((prev) => ({ ...prev, gpus: value }));
             }}
           />
           <TextField
@@ -68,7 +68,7 @@ export const ResourceForm: FC = () => {
             value={res.nprocs}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const value = e.target.value;
-              setRes((prev) => ({ ...prev, nprocs: value}));
+              setRes((prev) => ({ ...prev, nprocs: value }));
             }}
           />
           <TextField
@@ -81,7 +81,7 @@ export const ResourceForm: FC = () => {
             value={res.memory}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               const value = e.target.value;
-              setRes((prev) => ({ ...prev, memory: value}));
+              setRes((prev) => ({ ...prev, memory: value }));
             }}
           />
         </Stack>


### PR DESCRIPTION
Renders a simple interface by which the number of cpus, gpus, memory and number of processes can be determined. There is still the work to do, such as fiuring out how to use these numbers in the end workflow.


<img width="341" height="298" alt="image" src="https://github.com/user-attachments/assets/f7daeffa-8e8f-49cc-a452-7f71d574dde1" />
